### PR TITLE
Add link to open the example on run.dlang.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Example
     assert(horiz(u).approxEqual(1));
     assert(horiz(v).approxEqual(sqrt(0.5)));
 
+[![Open on run.dlang.io](https://img.shields.io/badge/run.dlang.io-open-blue.svg)](https://run.dlang.io/is/X4jUxq)
 
 Installation
 ------------


### PR DESCRIPTION
I used this link: https://run.dlang.io/is/X4jUxq

It's important `version="~>0.4"` means any version below 1.0.0 (so you might keep that in mind if you ever release a stable version.)