### PR TITLE
Fix #16 - better opEquals

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,5 +5,14 @@
 	],
 	"description": "A sum type with pattern matching",
 	"copyright": "Copyright © 2018, Paul Backus",
-	"license": "MIT"
+	"license": "MIT",
+	"configurations": [
+		{
+			"name": "default"
+		},
+		{
+			"name": "unittest",
+			"versions": ["Testing_sumtype"]
+		}
+	]
 }

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -289,27 +289,11 @@ public:
 		}
 	}
 
-	import std.meta: allSatisfy, staticMap;
-	import std.traits: isEqualityComparable, ConstOf;
+	import std.meta: allSatisfy;
+	import std.traits: isEqualityComparable;
 
-	static if (allSatisfy!(isEqualityComparable, staticMap!(ConstOf, Types))) {
-		/// Compares two `SumType`s for equality.
-		bool opEquals(const SumType!(TypeArgs) rhs) const
-		{
-			return this.match!((ref value) {
-				return rhs.match!((ref rhsValue) {
-					static if (is(typeof(value) == typeof(rhsValue))) {
-						return value == rhsValue;
-					} else {
-						return false;
-					}
-				});
-			});
-		}
-	} else static if (allSatisfy!(isEqualityComparable, Types)) {
-		/// ditto
-		bool opEquals(SumType!(TypeArgs) rhs)
-		{
+	static if( allSatisfy!(isEqualityComparable, Types)) {
+		bool opEquals(in SumType rhs) const {
 			return this.match!((ref value) {
 				return rhs.match!((ref rhsValue) {
 					static if (is(typeof(value) == typeof(rhsValue))) {
@@ -588,52 +572,6 @@ public:
 	auto b = MySum(Struct([Field()]));
 
 	assert(a == b);
-}
-
-// Compares types with const-only, mutable-only, and disabled opEquals
-// overloads without breaking value equality
-@safe unittest {
-	import std.traits;
-
-	struct MutableEquals
-	{
-		bool opEquals(MutableEquals rhs)
-		{
-			return true;
-		}
-	}
-
-	struct ConstEquals
-	{
-		bool opEquals(const ConstEquals rhs) const
-		{
-			return true;
-		}
-
-		@disable bool opEquals(ConstEquals rhs);
-	}
-
-	struct NoEquals
-	{
-		@disable bool opEquals(const NoEquals rhs) const;
-	}
-
-	alias SumA = SumType!(MutableEquals, int[]);
-	assert(__traits(compiles,
-		SumA(MutableEquals()) == SumA(MutableEquals())
-	));
-	assert(SumA([1, 2, 3]) == SumA([1, 2, 3]));
-
-	alias SumB = SumType!(ConstEquals, int[]);
-	assert(__traits(compiles,
-		SumB(ConstEquals()) == SumB(ConstEquals())
-	));
-	assert(SumB([1, 2, 3]) == SumB([1, 2, 3]));
-
-	alias SumC = SumType!NoEquals;
-	assert(!__traits(compiles,
-		SumC(NoEquals()) == SumC(NoEquals())
-	));
 }
 
 // toString
@@ -1192,4 +1130,49 @@ unittest {
 	assert(OverloadSet.fun(a) == "int");
 	assert(OverloadSet.fun(b) == "double");
 	assert(OverloadSet.fun(c) == "string");
+}
+
+
+// Github issue #16
+/*@safe pure*/ unittest {
+
+	assert(
+		Node(Struct(
+				"Outer",
+				[
+					 Node(Field(Type(Int()), "integer")),
+					 Node(Struct("Inner", [Node(Field(Type(Int()), "x"))])),
+					 Node(Field(Type(UserDefinedType("Inner")), "inner")),
+				]
+			)
+		)
+		==
+		Node(Struct(
+				"Outer",
+				[
+					 Node(Field(Type(Int()), "integer")),
+					 Node(Struct("Inner", [Node(Field(Type(Int()), "x"))])),
+					 Node(Field(Type(UserDefinedType("Inner")), "inner")),
+				]
+			)
+		)
+	);
+}
+
+version(Testing_sumtype) {
+	alias Node = SumType!(Struct, Field);
+
+	struct Struct {
+		string spelling;
+		Node[] nodes;
+	}
+
+	struct Field {
+		Type type;
+		string spelling;
+	}
+
+	alias Type = SumType!(Int, UserDefinedType);
+	struct Int {}
+	struct UserDefinedType { string spelling; }
 }

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -296,7 +296,7 @@ public:
 		bool opEquals(in SumType rhs) @safe const {
 			return this.match!((ref value) {
 				return rhs.match!((ref rhsValue) {
-					static if (is(typeof(value) == typeof(rhsValue))) {
+					static if (is(typeof(value == rhsValue) == bool)) {
 						return () @trusted { return value == rhsValue; }();
 					} else {
 						return false;

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -293,11 +293,11 @@ public:
 	import std.traits: isEqualityComparable;
 
 	static if( allSatisfy!(isEqualityComparable, Types)) {
-		bool opEquals(in SumType rhs) const {
+		bool opEquals(in SumType rhs) @safe const {
 			return this.match!((ref value) {
 				return rhs.match!((ref rhsValue) {
 					static if (is(typeof(value) == typeof(rhsValue))) {
-						return value == rhsValue;
+						return () @trusted { return value == rhsValue; }();
 					} else {
 						return false;
 					}
@@ -1134,7 +1134,7 @@ unittest {
 
 
 // Github issue #16
-/*@safe pure*/ unittest {
+@safe unittest {
 
 	assert(
 		Node(Struct(

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -292,12 +292,12 @@ public:
 	import std.meta: allSatisfy;
 	import std.traits: isEqualityComparable;
 
-	static if( allSatisfy!(isEqualityComparable, Types)) {
-		bool opEquals(in SumType rhs) @safe const {
+	static if (allSatisfy!(isEqualityComparable, Types)) {
+		bool opEquals(in SumType rhs) const {
 			return this.match!((ref value) {
 				return rhs.match!((ref rhsValue) {
-					static if (is(typeof(value == rhsValue) == bool)) {
-						return () @trusted { return value == rhsValue; }();
+					static if (is(typeof(value) == typeof(rhsValue))) {
+						return value == rhsValue;
 					} else {
 						return false;
 					}
@@ -1165,6 +1165,9 @@ version(Testing_sumtype) {
 	struct Struct {
 		string spelling;
 		Node[] nodes;
+		bool opEquals(in Struct other) @trusted @nogc pure nothrow const {
+			return spelling == other.spelling && nodes == other.nodes;
+		}
 	}
 
 	struct Field {


### PR DESCRIPTION
I deleted the tests for weird types with mutable `opEquals` and `@disable`d mutable opEquals. These types are degenerate - `opEquals` should always be `const`. The code is simpler as a result and a bug is fixed.

I tried to fix #16 without changing that, but it was a lot of effort and I still don't actually know what was going on.