### PR TITLE
Explicitly list DMD and LDC versions to test (not just the latest version)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,15 @@ branches:
     - master
 
 d:
-  - dmd
-  - ldc
+  - dmd-2.094.0
+  - dmd-2.093.1
+  - dmd-2.092.1
+  - dmd-2.091.1
+  - dmd-2.090.1
+  - ldc-1.23.0
+  - ldc-1.22.0
+  - ldc-1.21.0
+  - ldc-1.20.0
 
 script:
   - dub test --compiler=${DC}

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -1465,7 +1465,7 @@ private template Iota(size_t n)
 }
 
 @safe unittest {
-	assert(Iota!0 == AliasSeq!());
+	assert(is(Iota!0 == AliasSeq!()));
 	assert(Iota!1 == AliasSeq!(0));
 	assert(Iota!3 == AliasSeq!(0, 1, 2));
 }


### PR DESCRIPTION
Also remove unittest line that didn't work on older DMDs (can't compare `()` with `()` because the compiler thinks it's a type tuple).