### PR TITLE
Test with toolchain versions 2.088 and 2.089

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,14 @@ d:
   - dmd-2.092.1
   - dmd-2.091.1
   - dmd-2.090.1
+  - dmd-2.089.1
+  - dmd-2.088.1
   - ldc-1.23.0
   - ldc-1.22.0
   - ldc-1.21.0
   - ldc-1.20.0
+  - ldc-1.19.0
+  - ldc-1.18.0
 
 script:
   - dub test --compiler=${DC}

--- a/dub.json
+++ b/dub.json
@@ -8,7 +8,7 @@
 	"license": "BSL-1.0",
 
 	"toolchainRequirements": {
-		"frontend": ">=2.090.0"
+		"frontend": ">=2.088"
 	},
 
 	"buildTypes": {


### PR DESCRIPTION
2.088 is the earliest version of Phobos with ReplaceTypeUnless.

---

Let's see if this passes CI.