### PR TITLE
Structural sumtype

### DIFF
--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -2168,16 +2168,16 @@ unittest {
 }
 
 /**
- * A `SumType` wrapper that forwads methods and property access to its members.
+ * A `SumType` variant that forwads methods and property access to its members.
  *
  * A `StructuralSumType` functions like a
  * [https://en.wikipedia.org/wiki/Structural_type_system|structural] supertype
- * or "base class" of its members' types: any method or property common to
+ * of its members' types: any method or property common to
  * *all* member types (including operators) will also be available for the
  * `StructuralSumType`.
  *
  * All normal `SumType` operations, including pattern matching, are also
- * supported, by way of `alias this`.
+ * supported.
  */
 struct StructuralSumType(Types...)
 {
@@ -2187,34 +2187,7 @@ struct StructuralSumType(Types...)
 	 * The purpose of the leading underscore is to minimize the odds of a name
 	 * collision with one of the members' common properties.
 	 */
-	SumType!Types data;
-
-	/// Converts implicitly to the wrapped `SumType`
-	alias data this;
-
-	/// Constructs a `StructuralSumType` from a `SumType`
-	this()(auto ref SumType!Types data)
-	{
-		import core.lifetime: forward;
-
-		static if (isCopyable!(SumType!Types)) {
-			this.data = data;
-		} else {
-			this.data = forward!data;
-		}
-	}
-
-	/// ditto
-	this()(auto ref const(SumType!Types) data) const
-	{
-		this.data = data;
-	}
-
-	/// ditto
-	this()(auto ref immutable(SumType!Types) data) immutable
-	{
-		this.data = data;
-	}
+	private SumType!Types _data;
 
 	static foreach (T; Types) {
 		/// Constructs a `StructuralSumType` holding a specific value
@@ -2223,22 +2196,22 @@ struct StructuralSumType(Types...)
 			import core.lifetime: forward;
 
 			static if (isCopyable!T) {
-				data = SumType!Types(value);
+				_data = SumType!Types(value);
 			} else {
-				data = SumType!Types(forward!value);
+				_data = SumType!Types(forward!value);
 			}
 		}
 
 		/// ditto
 		this()(auto ref const(T) value) const
 		{
-			data = const(SumType!Types)(value);
+			_data = const(SumType!Types)(value);
 		}
 
 		/// ditto
 		this()(auto ref immutable(T) value) immutable
 		{
-			data = immutable(SumType!Types)(value);
+			_data = immutable(SumType!Types)(value);
 		}
 	}
 
@@ -2249,41 +2222,16 @@ struct StructuralSumType(Types...)
 			{
 				import core.lifetime: forward;
 
-				data = forward!rhs;
+				_data = forward!rhs;
 				return this;
 			}
 		}
 	}
 
-	static if (isAssignableTo!(SumType!Types)) {
-		/// Replaces the wrapped `SumType`
-		ref StructuralSumType opAssign()(auto ref SumType!Types rhs)
-		{
-			import core.lifetime: forward;
-
-			data = forward!rhs;
-			return this;
-		}
-
-		static if (isCopyable!(SumType!Types)) {
-			/// Copies the value from another `StructuralSumType` into this one
-			ref StructuralSumType opAssign(ref StructuralSumType rhs)
-			{
-				this = rhs.data;
-				return this;
-			}
-		} else {
-			@disable ref StructuralSumType opAssign(ref StructuralSumType rhs);
-		}
-
-		/// Moves the value from another `StructuralSumType` into this one
-		ref StructuralSumType opAssign(StructuralSumType rhs)
-		{
-			import core.lifetime: move;
-
-			this = move(rhs.data);
-			return this;
-		}
+	/// Compares a `StructuralSumType`'s value with another value
+	bool opEquals(Rhs)(auto ref Rhs rhs) const
+	{
+		return _data.match!((ref value) => value == rhs);
 	}
 }
 
@@ -2306,16 +2254,6 @@ struct StructuralSumType(Types...)
 	assert(__traits(compiles, immutable(MySum)(ia)));
 }
 
-// Construction from SumType
-@safe unittest {
-	alias Outer = StructuralSumType!int;
-	alias Inner = SumType!int;
-
-	assert(__traits(compiles, Outer(Inner(42))));
-	assert(__traits(compiles, const(Outer)(const(Inner)(42))));
-	assert(__traits(compiles, immutable(Outer)(immutable(Inner)(42))));
-}
-
 // Assignment
 @safe unittest {
 	alias MySum = StructuralSumType!(int, float);
@@ -2335,14 +2273,30 @@ struct StructuralSumType(Types...)
 	x = y;
 }
 
-// Assignment from SumType
+// Equality
+@safe unittest {
+	alias MySum = StructuralSumType!(int, float);
+
+	MySum x = MySum(123);
+	MySum y = MySum(123);
+	MySum z = MySum(456);
+	MySum w = MySum(123.0);
+	MySum v = MySum(456.0);
+
+	assert(x == 123);
+	assert(x == y);
+	assert(x != z);
+	assert((x == w) == (123 == cast(float) 123.0));
+	assert(x != v);
+}
+
+// Equality of const StructuralSumTypes
 @safe unittest {
 	alias MySum = StructuralSumType!int;
 
-	MySum x = 123;
-	SumType!int y = 456;
-
-	assert(__traits(compiles, x = y));
+	assert(__traits(compiles,
+		const(MySum)(123) == const(MySum)(456)
+	));
 }
 
 // Types with @disable this(this)

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -2275,6 +2275,25 @@ struct StructuralSumType(Types...)
 			}
 		});
 	}
+
+	/// Unary operators
+	auto ref opUnary(string op)() inout
+	{
+		return _data.match!((ref value) => mixin(op, "value"));
+	}
+
+	/// Binary operators
+	auto ref opBinary(string op, Rhs)(auto ref Rhs rhs) inout
+	{
+		return _data.match!((ref value) => mixin("value", op, "rhs"));
+	}
+
+	/// ditto
+	auto ref opBinaryRight(string op, Lhs)(auto ref Lhs lhs) inout
+	{
+		return _data.match!((ref value) => mixin("lhs", op, "value"));
+	}
+
 }
 
 // Construction from value
@@ -2546,6 +2565,31 @@ version (D_Exceptions)
 
 	StructuralSumType!S x;
 	assert(__traits(compiles, x.fun(NoCopy())));
+}
+
+// Unary operators
+@safe unittest {
+	alias MySum = StructuralSumType!int;
+
+	MySum x = 123;
+	const MySum y = 456;
+	immutable MySum z = 789;
+
+	assert(-x == -123);
+	assert(-y == -456);
+	assert(-z == -789);
+}
+
+// Binary operators
+@safe unittest {
+	alias MySum = StructuralSumType!int;
+
+	MySum x = 123;
+	const MySum y = 456;
+	immutable MySum z = 789;
+
+	assert(x + y == 579);
+	assert(z - y == 333);
 }
 
 static if (__traits(compiles, { import std.traits: isRvalueAssignable; })) {

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -2168,24 +2168,15 @@ unittest {
 }
 
 /**
- * A `SumType` wrapper that forwads methods and properties to its members.
+ * A [SumType] wrapper that provides direct access to methods and properties
+ * common to all of its members.
  *
- * A `StructuralSumType` functions like a
- * [https://en.wikipedia.org/wiki/Structural_type_system|structural] supertype
- * of its members' types: any method or property common to
- * *all* member types (including operators) will also be available for the
- * `StructuralSumType`.
- *
- * All normal `SumType` operations, including pattern matching, are also
- * supported.
+ * Attempting to access a property or call a method that is not available for
+ * all members will result in a compile-time error.
  */
 struct StructuralSumType(Types...)
 {
-	/**
-	 * Access the stored value as a [SumType] object.
-	 *
-	 * This can be used 
-	 */
+	/// Provides access to the stored value as a [SumType] object.
 	SumType!Types asSumType;
 
 	static foreach (T; Types) {
@@ -2242,6 +2233,10 @@ struct StructuralSumType(Types...)
 			static if (args.length == 0) {
 				return __traits(getMember, value, name);
 			} else static if (args.length == 1) {
+				/* If this is a "real" assignment, and not a property setter or
+				 * single-argument method call, it won't work if the right-hand
+				 * side is an AliasSeq.
+				 */
 				return __traits(getMember, value, name) = forward!(args[0]);
 			} else {
 				return __traits(getMember, value, name) = forward!args;

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -1318,7 +1318,7 @@ template match(handlers...)
 	 * Params:
 	 *   args = One or more [SumType] objects.
 	 */
-	auto match(SumTypes...)(auto ref SumTypes args)
+	auto ref match(SumTypes...)(auto ref SumTypes args)
 		if (allSatisfy!(isSumType, SumTypes) && args.length > 0)
 	{
 		return matchImpl!(Yes.exhaustive, handlers)(args);
@@ -1456,7 +1456,7 @@ template tryMatch(handlers...)
 	 * Params:
 	 *   args = One or more [SumType] objects.
 	 */
-	auto tryMatch(SumTypes...)(auto ref SumTypes args)
+	auto ref tryMatch(SumTypes...)(auto ref SumTypes args)
 		if (allSatisfy!(isSumType, SumTypes) && args.length > 0)
 	{
 		return matchImpl!(No.exhaustive, handlers)(args);
@@ -1520,7 +1520,7 @@ private template Iota(size_t n)
 
 private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
 {
-	auto matchImpl(SumTypes...)(auto ref SumTypes args)
+	auto ref matchImpl(SumTypes...)(auto ref SumTypes args)
 		if (allSatisfy!(isSumType, SumTypes) && args.length > 0)
 	{
 		/* The stride that the dim-th argument's tag is multiplied by when
@@ -2265,7 +2265,7 @@ struct StructuralSumType(Types...)
 	/// Assignment with an operator
 	auto ref opOpAssign(string op, this This, Rhs)(Rhs rhs)
 	{
-		return asSumType.match!((ref value) => mixin("value", op, "=", "rhs"));
+		return asSumType.match!(ref (ref value) => mixin("value", op, "=", "rhs"));
 	}
 
 	/// Comparison operators
@@ -2703,6 +2703,7 @@ version(none)
 
 	assert((x += 1) == 1);
 	assert((x += 2) == 3);
+	assert(((x += 1) += 1) == 5);
 }
 
 static if (__traits(compiles, { import std.traits: isRvalueAssignable; })) {

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -2293,7 +2293,12 @@ struct StructuralSumType(Types...)
 		return asSumType.match!((ref value) => value(forward!args));
 	}
 
-	// Index operator
+	/**
+	 * Index operator
+	 *
+	 * Currently supports indexing with any number of arguments, and slicing
+	 * with zero arguments.
+	 */
 	auto ref opIndex(this This, Args...)(auto ref Args args)
 	{
 		import core.lifetime: forward;
@@ -2301,7 +2306,7 @@ struct StructuralSumType(Types...)
 		return asSumType.match!(ref (ref value) => value[forward!args]);
 	}
 
-	// Slice operator
+	/// ditto
 	auto ref opIndex(this This)()
 	{
 		return asSumType.match!((ref value) => value[]);

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -2747,26 +2747,29 @@ version(none)
 }
 
 // Indexing
+version(D_BetterC) {} else
 @safe unittest {
-	int[3] a = [1, 2, 3];
-	StructuralSumType!(int[]) x = a[];
+	int[] a = [1, 2, 3];
+	StructuralSumType!(int[]) x = a;
 
 	assert(x[1] == 2);
 }
 
 // Index assignment
+version(D_BetterC) {} else
 @safe unittest {
-	int[3] a = [1, 2, 3];
-	StructuralSumType!(int[]) x = a[];
+	int[] a = [1, 2, 3];
+	StructuralSumType!(int[]) x = a;
 	x[1] = 4;
 
 	assert(a[1] == 4);
 }
 
 // Slicing
+version(D_BetterC) {} else
 @safe unittest {
-	int[3] a = [1, 2, 3];
-	StructuralSumType!(int[]) x = a[];
+	int[] a = [1, 2, 3];
+	StructuralSumType!(int[]) x = a;
 
 	assert(x[] == a[]);
 }

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -2262,6 +2262,12 @@ struct StructuralSumType(Types...)
 		return asSumType.match!((ref value) => mixin("lhs", op, "value"));
 	}
 
+	/// Assignment with an operator
+	auto ref opOpAssign(string op, this This, Rhs)(Rhs rhs)
+	{
+		return asSumType.match!((ref value) => mixin("value", op, "=", "rhs"));
+	}
+
 	/// Comparison operators
 	auto opCmp(this This, Rhs)(auto ref Rhs rhs)
 	{
@@ -2687,6 +2693,16 @@ version(none)
 	x(0) = 123;
 
 	assert(m == 123);
+}
+
+// Assignment + operator
+@safe unittest {
+	alias MySum = StructuralSumType!int;
+
+	MySum x = 0;
+
+	assert((x += 1) == 1);
+	assert((x += 2) == 3);
 }
 
 static if (__traits(compiles, { import std.traits: isRvalueAssignable; })) {

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -2507,6 +2507,26 @@ version (D_Exceptions)
 	assert(x.member == 456);
 }
 
+// Properties are lvalues
+// Needs fix for dlang issue 21243
+version(none)
+@safe unittest {
+	static struct A
+	{
+		int member;
+	}
+
+	static void inc(ref int n)
+	{
+		n++;
+	}
+
+	StructuralSumType!A x = A(42);
+	inc(x.member);
+
+	assert(x.member = 43);
+}
+
 // Member functions
 @safe unittest {
 	static struct A
@@ -2685,6 +2705,7 @@ version (D_BetterC) {} else
 }
 
 // Call operator that returns by ref
+// Needs fix for dlang issue 21243
 version(none)
 @safe unittest {
 	int m;


### PR DESCRIPTION
Features that are still missing:

- Full complement of `opIndex`/`opSlice`/`opDollar` overloads.
- Ability to return both lvalues and rvalues from `opDispatch`, `opCall`, `opIndex`, and probably others. (Blocked by a compiler bug.)