### PR TITLE
Fix #47 - Construction and assignment from lvalue require exact type match

### DIFF
--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -250,6 +250,8 @@ private enum isHashable(T) = __traits(compiles,
 	() nothrow @safe { hashOf(T.init); }
 );
 
+private enum hasPostblit(T) = __traits(hasPostblit, T);
+
 /**
  * A [tagged union](https://en.wikipedia.org/wiki/Tagged_union) that can hold a
  * single value from any of a specified set of types.
@@ -387,8 +389,6 @@ public:
 	}
 
 	static if (anySatisfy!(hasElaborateCopyConstructor, Types)) {
-		private enum hasPostblit(T) = __traits(hasPostblit, T);
-
 		static if (
 			allSatisfy!(isCopyable, Map!(InoutOf, Types))
 			&& !anySatisfy!(hasPostblit, Map!(InoutOf, Types))

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -289,6 +289,7 @@ private:
 
 	union Storage
 	{
+		// Workaround for dlang issue 20068
 		template memberName(T)
 			if (IndexOf!(T, Types) >= 0)
 		{
@@ -337,6 +338,7 @@ public:
 		{
 			import core.lifetime: forward;
 
+			// Workaround for dlang issue 21229
 			storage = () {
 				static if (isCopyable!T) {
 					mixin("Storage newStorage = { ",

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -591,11 +591,7 @@ public:
 		/// Calls the destructor of the `SumType`'s current value.
 		~this()
 		{
-			this.match!((ref value) {
-				static if (hasElaborateDestructor!(typeof(value))) {
-					destroy(value);
-				}
-			});
+			this.match!destroyIfOwner;
 		}
 	}
 

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -340,7 +340,8 @@ public:
 			storage = () {
 				static if (isCopyable!T) {
 					mixin("Storage newStorage = { ",
-						Storage.memberName!T, ": value",
+						// Workaround for dlang issue 21542
+						Storage.memberName!T, ": (__ctfe ? value : forward!value)",
 					" };");
 				} else {
 					mixin("Storage newStorage = { ",

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -1598,18 +1598,11 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
 		 * Because D does not allow a struct to be the controlling expression
 		 * of a switch statement, we cannot dispatch on the TagTuple directly.
 		 * Instead, we must map each TagTuple to a unique integer and generate
-		 * a case label for each of those integers. This mapping is implemented
-		 * in `fromCaseId` and `toCaseId`.
+		 * a case label for each of those integers.
 		 *
-		 * The mapping is done by pretending we are indexing into an
-		 * `args.length`-dimensional static array of type
-		 *
-		 *   ubyte[SumTypes[0].Types.length]...[SumTypes[$-1].Types.length]
-		 *
-		 * ...where each element corresponds to the TagTuple whose tags can be
-		 * used (in reverse order) as indices to retrieve it. The caseId for
-		 * that TagTuple is the (hypothetical) offset, in bytes, of its
-		 * corresponding element.
+		 * This mapping is implemented in `fromCaseId` and `toCaseId`. It uses
+		 * the same technique that's used to map index tuples to memory offsets
+		 * in a multidimensional static array.
 		 *
 		 * For example, when `args` consists of two SumTypes with two member
 		 * types each, the TagTuples corresponding to each case label are:
@@ -1618,6 +1611,9 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
 		 *   case 1:  TagTuple([1, 0])
 		 *   case 2:  TagTuple([0, 1])
 		 *   case 3:  TagTuple([1, 1])
+		 *
+		 * When there is only one argument, the caseId is equal to that
+		 * argument's tag.
 		 */
 		static struct TagTuple
 		{
@@ -1702,10 +1698,6 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
 		/* The total number of cases is
 		 *
 		 *   Π SumTypes[i].Types.length for 0 ≤ i < SumTypes.length
-		 *
-		 * Or, equivalently,
-		 *
-		 *   ubyte[SumTypes[0].Types.length]...[SumTypes[$-1].Types.length].sizeof
 		 *
 		 * Conveniently, this is equal to stride!(SumTypes.length), so we can
 		 * use that function to compute it.


### PR DESCRIPTION
This incurs an extra copy in some cases (assignment from non-mutable lvalues). LDC is able to combine them when compiling with optimizations enabled, but DMD is not.