### PR TITLE
Fix template constraint of SumType.opEquals

### DIFF
--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -572,7 +572,7 @@ public:
 	 * contain values of the same type, and those values are equal.
 	 */
 	bool opEquals(this This, Rhs)(auto ref Rhs rhs)
-		if (is(CommonType!(This, Rhs)))
+		if (!is(CommonType!(This, Rhs) == void))
 	{
 		static if (is(This == Rhs)) {
 			return AliasSeq!(this, rhs).match!((ref value, ref rhsValue) {


### PR DESCRIPTION
CommonType returns `void`, not an error, for types that have no common
type, so we must check for `void` explicitly.

Fixes #53 on Github.