### PR TITLE
Run tests with -preview=fieldwise

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -11,6 +11,8 @@
 		"frontend": ">=2.094"
 	},
 
+	"dflags": ["-preview=fieldwise"],
+
 	"buildTypes": {
 		"unittest-dip1000": {
 			"buildOptions": ["unittests", "debugMode", "debugInfo"],

--- a/test-betterc.sh
+++ b/test-betterc.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-dmd -unittest -g -betterC -I=src -i -run test_betterc.d
+DFLAGS="-preview=fieldwise"
+dmd $DFLAGS -unittest -g -betterC -I=src -i -run test_betterc.d


### PR DESCRIPTION
This fixes a spurious test failure on Windows, and should prevent
similar failures from occurring in the future.