### PR TITLE
Allow storing scope pointers in a SumType

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,15 +16,7 @@ jobs:
           - macOS-latest
         dc:
           - dmd-latest
-          - dmd-2.097.2
-          - dmd-2.096.1
-          - dmd-2.095.1
-          - dmd-2.094.2
           - ldc-latest
-          - ldc-1.27.1
-          - ldc-1.26.0
-          - ldc-1.25.1
-          - ldc-1.24.0
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/dub.json
+++ b/dub.json
@@ -8,7 +8,7 @@
 	"license": "BSL-1.0",
 
 	"toolchainRequirements": {
-		"frontend": ">=2.094"
+		"frontend": ">=2.098"
 	},
 
 	"dflags": ["-preview=fieldwise"],


### PR DESCRIPTION
Previously, the assignment of the local variable 'newStorage' to the
longer-lived member variable 'storage' caused scope inference to
(correctly) fail.

newStorage was necessary to work around dlang issues 21229 and 22118. As
of DMD 2.098.0, those issues have been fixed, and newStorage can be
safely removed.

Fixes #68 on Github.

---

This PR can be merged as soon as LDC 1.28 is released with fixes for the compiler issues mentioned above.