### PR TITLE
Add example of memory corruption to opAssign docs

### DIFF
--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -479,14 +479,35 @@ public:
 			/**
 			 * Assigns a value to a `SumType`.
 			 *
-			 * Assigning to a `SumType` is `@system` if any of the `SumType`'s
-			 * $(I other) members contain pointers or references, since those
-			 * members may be reachable through external references, and
-			 * overwriting them could therefore lead to memory corruption.
+			 * If any of the `SumType`'s members other than the one being assigned
+			 * to contain pointers or references, it is possible for the assignment
+			 * to cause memory corruption (see the
+			 * ["Memory corruption" example](#memory-corruption) below for an
+			 * illustration of how). Therefore, such assignments are considered
+			 * `@system`.
 			 *
 			 * An individual assignment can be `@trusted` if the caller can
-			 * guarantee that, when the assignment occurs, there are no
-			 * outstanding references to any such members.
+			 * guarantee that there are no outstanding references to any `SumType`
+			 * members that contain pointers or references at the time the
+			 * assignment occurs.
+			 *
+			 * Examples:
+			 *
+			 * $(H3 Memory corruption)
+			 *
+			 * This example shows how assignment to a `SumType` can be used to
+			 * cause memory corruption in `@system` code. In `@safe` code, the
+			 * assignment `s = 123` would not be allowed.
+			 *
+			 * ---
+			 * SumType!(int*, int) s = new int;
+			 * s.tryMatch!(
+			 *     (ref int* p) {
+			 *         s = 123; // overwrites `p`
+			 *         return *p; // undefined behavior
+			 *     }
+			 * );
+			 * ---
 			 */
 			ref SumType opAssign(T rhs)
 			{


### PR DESCRIPTION
This makes it clearer why SumType.opAssign must sometimes be @system.