### PR TITLE
Remove local copy of isRvalueAssignable

### DIFF
--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -224,7 +224,7 @@ import std.meta: AliasSeq, Filter, IndexOf = staticIndexOf, Map = staticMap;
 import std.meta: NoDuplicates;
 import std.meta: anySatisfy, allSatisfy;
 import std.traits: hasElaborateCopyConstructor, hasElaborateDestructor;
-import std.traits: isAssignable, isCopyable, isStaticArray;
+import std.traits: isAssignable, isCopyable, isRvalueAssignable, isStaticArray;
 import std.traits: ConstOf, ImmutableOf, InoutOf, TemplateArgsOf;
 import std.traits: CommonType;
 import std.typecons: ReplaceTypeUnless;
@@ -2402,15 +2402,6 @@ version (D_Exceptions)
 			return x.match!((inout(int[]) a) => a);
 		}
 	}));
-}
-
-static if (__traits(compiles, { import std.traits: isRvalueAssignable; })) {
-	import std.traits: isRvalueAssignable;
-} else private {
-	enum isRvalueAssignable(Lhs, Rhs = Lhs) = __traits(compiles, lvalueOf!Lhs = rvalueOf!Rhs);
-	struct __InoutWorkaroundStruct{}
-	@property T rvalueOf(T)(inout __InoutWorkaroundStruct = __InoutWorkaroundStruct.init);
-	@property ref T lvalueOf(T)(inout __InoutWorkaroundStruct = __InoutWorkaroundStruct.init);
 }
 
 private void destroyIfOwner(T)(ref T value)


### PR DESCRIPTION
std.traits.isRvalueAssignable was made public in Phobos 2.095.0. Since
sumtype now requires DMD/Phobos 2.098 or later, the version from
std.traits can be used unconditionally.