### PR TITLE
Remove SumType's invariant

### DIFF
--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -645,18 +645,6 @@ public:
 		}
 	}
 
-	invariant {
-		this.match!((ref value) {
-			static if (is(typeof(value) == class)) {
-				if (value !is null) {
-					assert(value);
-				}
-			} else static if (is(typeof(value) == struct)) {
-				assert(&value);
-			}
-		});
-	}
-
 	version (D_BetterC) {} else
 	/**
 	 * Returns a string representation of the `SumType`'s current value.
@@ -1167,34 +1155,6 @@ version (D_BetterC) {} else
 	assert(!__traits(compiles, () @safe {
 		x = MySum(123);
 	}));
-}
-
-// Types with invariants
-// Disabled in BetterC due to use of exceptions
-version (D_BetterC) {} else
-@system unittest {
-	import std.exception: assertThrown;
-	import core.exception: AssertError;
-
-	struct S
-	{
-		int i;
-		invariant { assert(i >= 0); }
-	}
-
-	class C
-	{
-		int i;
-		invariant { assert(i >= 0); }
-	}
-
-	SumType!S x;
-	x.match!((ref v) { v.i = -1; });
-	assertThrown!AssertError(assert(&x));
-
-	SumType!C y = new C();
-	y.match!((ref v) { v.i = -1; });
-	assertThrown!AssertError(assert(&y));
 }
 
 // Calls value postblit on self-assignment


### PR DESCRIPTION
According to earlier versions of the language spec, checking the
invariant of a struct would also cause its fields' invariants to be
checked, recursively. SumType's invariant was added to make SumType
behave consistently with other structs in this regard.

The spec, however, was wrong: invariants of struct fields are not
checked unless the field is accessed directly, and never have been.
Thus, to make SumType behave consistently with other structs, its
invariant must be removed.

This change should not break any valid programs, since code that relies
on the failure of an invariant has undefined behavior per the spec.

Spec correction PR: https://github.com/dlang/dlang.org/pull/3405
Phobos PR: https://github.com/dlang/phobos/pull/8558