### PR TITLE
Reduce template overhead of match

### DIFF
--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -1988,10 +1988,16 @@ private enum typeCount(SumType) = SumType.Types.length;
 template handlerArgs(size_t caseId, typeCounts...)
 {
 	enum tags = TagTuple!typeCounts.fromCaseId(caseId);
-	enum argsFrom(size_t i: tags.length) = "";
-	enum argsFrom(size_t i) = "args[" ~ toCtString!i ~ "].get!(SumTypes[" ~ toCtString!i ~ "]" ~
-		".Types[" ~ toCtString!(tags[i]) ~ "])(), " ~ argsFrom!(i + 1);
-	enum handlerArgs = argsFrom!0;
+
+	alias handlerArgs = AliasSeq!();
+
+	static foreach (i; 0 .. tags.length) {
+		handlerArgs = AliasSeq!(
+			handlerArgs,
+			"args[" ~ toCtString!i ~ "].get!(SumTypes[" ~ toCtString!i ~ "]" ~
+			".Types[" ~ toCtString!(tags[i]) ~ "])(), "
+		);
+	}
 }
 
 // Matching

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -1777,9 +1777,10 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
 	auto ref matchImpl(SumTypes...)(auto ref SumTypes args)
 		if (allSatisfy!(isSumType, SumTypes) && args.length > 0)
 	{
-		alias stride(size_t i) = .stride!(i, Map!(typeCount, SumTypes));
+		alias typeCounts = Map!(typeCount, SumTypes);
 
-		alias TagTuple = .TagTuple!(Map!(typeCount, SumTypes));
+		alias stride(size_t i) = .stride!(i, typeCounts);
+		alias TagTuple = .TagTuple!typeCounts;
 
 		/*
 		 * A list of arguments to be passed to a handler needed for the case

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -1772,32 +1772,6 @@ private template Iota(size_t n)
 	assert(Iota!3 == AliasSeq!(0, 1, 2));
 }
 
-/* The number that the dim-th argument's tag is multiplied by when
- * converting TagTuples to and from case indices ("caseIds").
- *
- * Named by analogy to the stride that the dim-th index into a
- * multidimensional static array is multiplied by to calculate the
- * offset of a specific element.
- */
-private size_t stride(size_t dim, lengths...)()
-{
-	import core.checkedint: mulu;
-
-	size_t result = 1;
-	bool overflow = false;
-
-	static foreach (i; 0 .. dim) {
-		result = mulu(result, lengths[i], overflow);
-	}
-
-	/* The largest number matchImpl uses, numCases, is calculated with
-	 * stride!(SumTypes.length), so as long as this overflow check
-	 * passes, we don't need to check for overflow anywhere else.
-	 */
-	assert(!overflow, "Integer overflow");
-	return result;
-}
-
 private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
 {
 	auto ref matchImpl(SumTypes...)(auto ref SumTypes args)
@@ -1921,11 +1895,8 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
 	}
 }
 
-// Predicate for staticMap
-private enum typeCount(SumType) = SumType.Types.length;
-
-/* A TagTuple represents a single possible set of tags that `args`
- * could have at runtime.
+/* A TagTuple represents a single possible set of tags that the arguments to
+ * `matchImpl` could have at runtime.
  *
  * Because D does not allow a struct to be the controlling expression
  * of a switch statement, we cannot dispatch on the TagTuple directly.
@@ -1992,6 +1963,35 @@ private struct TagTuple(typeCounts...)
 		return result;
 	}
 }
+
+/* The number that the dim-th argument's tag is multiplied by when
+ * converting TagTuples to and from case indices ("caseIds").
+ *
+ * Named by analogy to the stride that the dim-th index into a
+ * multidimensional static array is multiplied by to calculate the
+ * offset of a specific element.
+ */
+private size_t stride(size_t dim, lengths...)()
+{
+	import core.checkedint: mulu;
+
+	size_t result = 1;
+	bool overflow = false;
+
+	static foreach (i; 0 .. dim) {
+		result = mulu(result, lengths[i], overflow);
+	}
+
+	/* The largest number matchImpl uses, numCases, is calculated with
+	 * stride!(SumTypes.length), so as long as this overflow check
+	 * passes, we don't need to check for overflow anywhere else.
+	 */
+	assert(!overflow, "Integer overflow");
+	return result;
+}
+
+// Predicate for staticMap
+private enum typeCount(SumType) = SumType.Types.length;
 
 // Matching
 @safe unittest {

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -1781,19 +1781,7 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
 
 		alias stride(size_t i) = .stride!(i, typeCounts);
 		alias TagTuple = .TagTuple!typeCounts;
-
-		/*
-		 * A list of arguments to be passed to a handler needed for the case
-		 * labeled with `caseId`.
-		 */
-		template handlerArgs(size_t caseId)
-		{
-			enum tags = TagTuple.fromCaseId(caseId);
-			enum argsFrom(size_t i: tags.length) = "";
-			enum argsFrom(size_t i) = "args[" ~ toCtString!i ~ "].get!(SumTypes[" ~ toCtString!i ~ "]" ~
-				".Types[" ~ toCtString!(tags[i]) ~ "])(), " ~ argsFrom!(i + 1);
-			enum handlerArgs = argsFrom!0;
-		}
+		alias handlerArgs(size_t caseId) = .handlerArgs!(caseId, typeCounts);
 
 		/* An AliasSeq of the types of the member values in the argument list
 		 * returned by `handlerArgs!caseId`.
@@ -1993,6 +1981,18 @@ private size_t stride(size_t dim, lengths...)()
 
 // Predicate for staticMap
 private enum typeCount(SumType) = SumType.Types.length;
+
+/* A list of arguments to be passed to a handler needed for the case
+ * labeled with `caseId`.
+ */
+template handlerArgs(size_t caseId, typeCounts...)
+{
+	enum tags = TagTuple!typeCounts.fromCaseId(caseId);
+	enum argsFrom(size_t i: tags.length) = "";
+	enum argsFrom(size_t i) = "args[" ~ toCtString!i ~ "].get!(SumTypes[" ~ toCtString!i ~ "]" ~
+		".Types[" ~ toCtString!(tags[i]) ~ "])(), " ~ argsFrom!(i + 1);
+	enum handlerArgs = argsFrom!0;
+}
 
 // Matching
 @safe unittest {

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -1777,41 +1777,56 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
 	auto ref matchImpl(SumTypes...)(auto ref SumTypes args)
 		if (allSatisfy!(isSumType, SumTypes) && args.length > 0)
 	{
-		alias typeCounts = Map!(typeCount, SumTypes);
+		// Single dispatch (fast path)
+		static if (args.length == 1) {
+			/* When there's only one argument, the caseId is just that
+			 * argument's tag, so there's no need to use TagTuple.
+			 */
+			enum handlerArgs(size_t caseId) =
+				"args[0].get!(SumTypes[0].Types[" ~ toCtString!caseId ~ "])()";
 
-		alias stride(size_t i) = .stride!(i, typeCounts);
-		alias TagTuple = .TagTuple!typeCounts;
-		alias handlerArgs(size_t caseId) = .handlerArgs!(caseId, typeCounts);
+			alias valueTypes(size_t caseId) =
+				typeof(args[0].get!(SumTypes[0].Types[caseId])());
 
-		/* An AliasSeq of the types of the member values in the argument list
-		 * returned by `handlerArgs!caseId`.
-		 *
-		 * Note that these are the actual (that is, qualified) types of the
-		 * member values, which may not be the same as the types listed in
-		 * the arguments' `.Types` properties.
-		 */
-		template valueTypes(size_t caseId)
-		{
-			enum tags = TagTuple.fromCaseId(caseId);
+			enum numCases = SumTypes[0].Types.length;
+		// Multiple dispatch (slow path)
+		} else {
+			alias typeCounts = Map!(typeCount, SumTypes);
+			alias stride(size_t i) = .stride!(i, typeCounts);
+			alias TagTuple = .TagTuple!typeCounts;
 
-			template getType(size_t i)
+			alias handlerArgs(size_t caseId) = .handlerArgs!(caseId, typeCounts);
+
+			/* An AliasSeq of the types of the member values in the argument
+			 * list returned by `handlerArgs!caseId`.
+			 *
+			 * Note that these are the actual (that is, qualified) types of the
+			 * member values, which may not be the same as the types listed in
+			 * the arguments' `.Types` properties.
+			 */
+			template valueTypes(size_t caseId)
 			{
-				enum tid = tags[i];
-				alias T = SumTypes[i].Types[tid];
-				alias getType = typeof(args[i].get!T());
+				enum tags = TagTuple.fromCaseId(caseId);
+
+				template getType(size_t i)
+				{
+					enum tid = tags[i];
+					alias T = SumTypes[i].Types[tid];
+					alias getType = typeof(args[i].get!T());
+				}
+
+				alias valueTypes = Map!(getType, Iota!(tags.length));
 			}
 
-			alias valueTypes = Map!(getType, Iota!(tags.length));
+			/* The total number of cases is
+			 *
+			 *   Π SumTypes[i].Types.length for 0 ≤ i < SumTypes.length
+			 *
+			 * Conveniently, this is equal to stride!(SumTypes.length), so we
+			 * can use that function to compute it.
+			 */
+			enum numCases = stride!(SumTypes.length);
 		}
-
-		/* The total number of cases is
-		 *
-		 *   Π SumTypes[i].Types.length for 0 ≤ i < SumTypes.length
-		 *
-		 * Conveniently, this is equal to stride!(SumTypes.length), so we can
-		 * use that function to compute it.
-		 */
-		enum numCases = stride!(SumTypes.length);
 
 		/* Guaranteed to never be a valid handler index, since
 		 * handlers.length <= size_t.max.
@@ -1861,7 +1876,13 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
 			mixin("alias ", handlerName!hid, " = handler;");
 		}
 
-		immutable argsId = TagTuple(args).toCaseId;
+		// Single dispatch (fast path)
+		static if (args.length == 1) {
+			immutable argsId = args[0].tag;
+		// Multiple dispatch (slow path)
+		} else {
+			immutable argsId = TagTuple(args).toCaseId;
+		}
 
 		final switch (argsId) {
 			static foreach (caseId; 0 .. numCases) {

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -1921,6 +1921,7 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
 	}
 }
 
+// Predicate for staticMap
 private enum typeCount(SumType) = SumType.Types.length;
 
 /* A TagTuple represents a single possible set of tags that `args`

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -1805,7 +1805,7 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
 	{
 		alias stride(size_t i) = .stride!(i, Map!(typeCount, SumTypes));
 
-		alias TagTuple = .TagTuple!SumTypes;
+		alias TagTuple = .TagTuple!(Map!(typeCount, SumTypes));
 
 		/*
 		 * A list of arguments to be passed to a handler needed for the case
@@ -1946,20 +1946,21 @@ private enum typeCount(SumType) = SumType.Types.length;
  * When there is only one argument, the caseId is equal to that
  * argument's tag.
  */
-private struct TagTuple(SumTypes...)
+private struct TagTuple(typeCounts...)
 {
-	size_t[SumTypes.length] tags;
+	size_t[typeCounts.length] tags;
 	alias tags this;
 
-	alias stride(size_t i) = .stride!(i, Map!(typeCount, SumTypes));
+	alias stride(size_t i) = .stride!(i, typeCounts);
 
 	invariant {
 		static foreach (i; 0 .. tags.length) {
-			assert(tags[i] < SumTypes[i].Types.length);
+			assert(tags[i] < typeCounts[i]);
 		}
 	}
 
-	this(ref const(SumTypes) args)
+	this(SumTypes...)(ref const SumTypes args)
+		if (allSatisfy!(isSumType, SumTypes) && args.length == typeCounts.length)
 	{
 		static foreach (i; 0 .. tags.length) {
 			tags[i] = args[i].tag;


### PR DESCRIPTION
The changes in this PR can be grouped into two categories:

1. Refactoring of helper templates for `matchImpl` to eliminate unnecessary instantiations.
2. Addition of a fast path for single dispatch to `matchImpl`.

Altogether, these changes reduce the time taken to run `sumtype`'s test suite by about 14%.

Performance data, from my personal laptop:

### Before

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `dmd -unittest -main -run src/sumtype.d` | 1.545 ± 0.056 | 1.492 | 1.673 | 1.00 |

### With refactoring

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `dmd -unittest -main -run src/sumtype.d` | 1.387 ± 0.058 | 1.342 | 1.530 | 1.00 |

### With refactoring and fast path

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `dmd -unittest -main -run src/sumtype.d` | 1.329 ± 0.062 | 1.274 | 1.476 | 1.00 |