### PR TITLE
Fix canMatch for ref return of non-copyable type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,17 +16,13 @@ jobs:
           - macOS-latest
         dc:
           - dmd-latest
-          - dmd-2.099.1
-          - dmd-2.098.1
+          - dmd-2.101.2
           - ldc-latest
-          - ldc-1.29.0
-          - ldc-1.28.1
+          - ldc-1.31.0
         exclude:
           # macOS requires DMD >= 2.107.1
           - os: macOS-latest
-            dc: dmd-2.099.1
-          - os: macOS-latest
-            dc: dmd-2.098.1
+            dc: dmd-2.101.2
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/dub.json
+++ b/dub.json
@@ -8,7 +8,7 @@
 	"license": "BSL-1.0",
 
 	"toolchainRequirements": {
-		"frontend": ">=2.098"
+		"frontend": ">=2.101"
 	},
 
 	"dflags": ["-preview=fieldwise"],

--- a/src/sumtype.d
+++ b/src/sumtype.d
@@ -1729,7 +1729,7 @@ class MatchException : Exception
 template canMatch(alias handler, Ts...)
 	if (Ts.length > 0)
 {
-	enum canMatch = is(typeof((ref Ts args) => handler(args)));
+	enum canMatch = is(typeof(auto ref (ref Ts args) => handler(args)));
 }
 
 ///
@@ -1750,6 +1750,20 @@ template canMatch(alias handler, Ts...)
 
 	assert(canMatch!(OverloadSet.fun, int));
 	assert(canMatch!(OverloadSet.fun, double));
+}
+
+// Allows returning non-copyable types by ref
+// https://github.com/dlang/phobos/issues/10647
+@safe unittest {
+	static struct NoCopy
+	{
+		@disable this(this);
+	}
+
+	static NoCopy lvalue;
+	static ref handler(int _) => lvalue;
+
+	assert(canMatch!(handler, int));
 }
 
 // Like aliasSeqOf!(iota(n)), but works in BetterC


### PR DESCRIPTION
Frontend requirement is bumped to 2.101 for access to auto ref lambdas.

Phobos PR: https://github.com/dlang/phobos/pull/10648